### PR TITLE
add CreateOrganizationMembership Method.

### DIFF
--- a/zendesk/organization_membership.go
+++ b/zendesk/organization_membership.go
@@ -53,3 +53,25 @@ func (z *Client) DeleteOrganizationMembership(ctx context.Context, orgMemID int6
 
 	return nil
 }
+
+// CreateOrganizationMembership はメンバーシップ(組織-ユーザ紐付け情報)を1件作成します
+// ref: https://developer.zendesk.com/api-reference/ticketing/organizations/organization_memberships/#create-membership
+func (z *Client) CreateOrganizationMembership(ctx context.Context, userID, organizationID int64) (OrganizationMembership, error) {
+	var data, result struct {
+		OrganizationMembership OrganizationMembership `json:"organization_membership"`
+	}
+	data.OrganizationMembership.UserID = userID
+	data.OrganizationMembership.OrganizationID = organizationID
+
+	body, err := z.post(ctx, "/organization_memberships.json", data)
+	if err != nil {
+		return OrganizationMembership{}, err
+	}
+
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return OrganizationMembership{}, err
+	}
+
+	return result.OrganizationMembership, nil
+}


### PR DESCRIPTION
## 関連URL
- Zendesk APIリファレンス
    - [organization_memberships/#create-membership](https://developer.zendesk.com/api-reference/ticketing/organizations/organization_memberships/#create-membership)

## なぜこの変更をするのか
- DATA_ANALYSIS-328の対応をするにあたり、必要な処理が不足していたため

## この変更によりどこが影響を受けるのか
- CreateOrganizationMembershipメソッドを追加したのみ。他への影響は特にない想定

## レビュワー担当者は何を確認すればいいのか
- [ ] go-zendeskの既存コードと整合性があること(独自スタイルになっていないこと)
- [ ] コードとAPIリファレンスでインプット・アウトプット定義が合致していること